### PR TITLE
Add main menu and selection screens

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -24,3 +24,29 @@ button {
     padding: 10px 20px;
     font-size: 1.2em;
 }
+.hidden {
+    display: none;
+}
+#characters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+#characters img {
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    margin: 10px;
+    cursor: pointer;
+    border: 2px solid transparent;
+}
+#characters img.selected {
+    border-color: red;
+}
+#stages {
+    list-style: none;
+    padding: 0;
+}
+#stages li {
+    margin: 10px;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,18 +2,30 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Mortal Kombat Clone</title>
+    <title>MORTAL KABROS</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+    <audio id="bgm" src="audio/theme.mp3" loop></audio>
     <div id="menu">
         <img src="Sprites/Fondos/PortadaPrincipal.png" alt="Portada" class="cover">
-        <h1>Juego Mortal Kombat</h1>
+        <h1>MORTAL KABROS</h1>
         <ul>
-            <li><button id="start-btn">Iniciar</button></li>
+            <li><button id="play-btn">Jugar</button></li>
+            <li><button id="local-btn">1 vs 1 Local</button></li>
+            <li><button id="ai-btn">1 vs IA</button></li>
             <li><button id="options-btn">Opciones</button></li>
-            <li><button id="exit-btn">Salir</button></li>
+            <li><button id="credits-btn">Créditos</button></li>
         </ul>
+    </div>
+    <div id="character-select" class="hidden">
+        <h2>Selecciona tu Kabro</h2>
+        <div id="characters"></div>
+        <button id="next-stage-btn" disabled>Siguiente</button>
+    </div>
+    <div id="stage-select" class="hidden">
+        <h2>Escoge escenario</h2>
+        <ul id="stages"></ul>
     </div>
     <script src="js/main.js"></script>
 </body>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,11 +1,89 @@
-document.getElementById('start-btn').addEventListener('click', function() {
-    alert('Iniciando juego...');
+const menu = document.getElementById('menu');
+const charScreen = document.getElementById('character-select');
+const stageScreen = document.getElementById('stage-select');
+const charactersDiv = document.getElementById('characters');
+const stagesList = document.getElementById('stages');
+const nextStageBtn = document.getElementById('next-stage-btn');
+const bgm = document.getElementById('bgm');
+
+const characters = [
+    {name: 'Fantasma Tuerto', img: 'Sprites/Imagenes perfil de los kabros/Fantasma tuerto.jpg'},
+    {name: 'Pescao Humano', img: 'Sprites/Imagenes perfil de los kabros/Pescao Humano.jpg'},
+    {name: 'Pino Negro', img: 'Sprites/Imagenes perfil de los kabros/Pino Negro.jpg'},
+    {name: 'Presidente Democratico', img: 'Sprites/Imagenes perfil de los kabros/Presidente Democratico .jpg'},
+    {name: 'Sabio Comediante', img: 'Sprites/Imagenes perfil de los kabros/Sabio Comediante.jpg'},
+    {name: 'Troll Manco', img: 'Sprites/Imagenes perfil de los kabros/Troll Manco .jpg'}
+];
+
+const stages = [
+    'Bosque de la Ira',
+    'Ruinas del Orden',
+    'Circo del Dolor',
+    'Caverna Espinada'
+];
+
+let selections = [];
+let currentPlayer = 1;
+
+function startCharacterSelect() {
+    menu.classList.add('hidden');
+    charScreen.classList.remove('hidden');
+    charactersDiv.innerHTML = '';
+    selections = [];
+    currentPlayer = 1;
+    characters.forEach((c, index) => {
+        const img = document.createElement('img');
+        img.src = c.img;
+        img.alt = c.name;
+        img.addEventListener('click', () => selectCharacter(index, img));
+        charactersDiv.appendChild(img);
+    });
+    nextStageBtn.disabled = true;
+    bgm.play();
+}
+
+function selectCharacter(index, img) {
+    if (img.classList.contains('selected')) return;
+    img.classList.add('selected');
+    selections.push(characters[index]);
+    if (selections.length === 2) {
+        nextStageBtn.disabled = false;
+    }
+}
+
+nextStageBtn.addEventListener('click', () => {
+    if (selections.length < 2) return;
+    charScreen.classList.add('hidden');
+    stageScreen.classList.remove('hidden');
+    stagesList.innerHTML = '';
+    stages.forEach(stage => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = stage;
+        btn.addEventListener('click', () => selectStage(stage));
+        li.appendChild(btn);
+        stagesList.appendChild(li);
+    });
 });
 
-document.getElementById('options-btn').addEventListener('click', function() {
+function selectStage(stage) {
+    alert('Combate entre ' + selections[0].name + ' y ' + selections[1].name + ' en ' + stage + '!');
+    stageScreen.classList.add('hidden');
+    menu.classList.remove('hidden');
+    bgm.pause();
+    bgm.currentTime = 0;
+}
+
+// Menu buttons
+['play-btn','local-btn','ai-btn'].forEach(id => {
+    const btn = document.getElementById(id);
+    if (btn) btn.addEventListener('click', startCharacterSelect);
+});
+
+document.getElementById('options-btn').addEventListener('click', () => {
     alert('Opciones no disponibles');
 });
 
-document.getElementById('exit-btn').addEventListener('click', function() {
-    alert('Hasta luego');
+document.getElementById('credits-btn').addEventListener('click', () => {
+    alert('Creado por Kabros Studios');
 });


### PR DESCRIPTION
## Summary
- update menu UI in `index.html`
- provide basic stylesheet and hide/show helpers
- implement character and stage select logic in `main.js`
- add placeholder theme audio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861aab0d46c8329a9c1240dcf87dcd0